### PR TITLE
Refactors for when and unless

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Nav::define(fn ($user) => [
     Nav::item('Dashboard')
         ->for('dashboard')
         ->icon('dashboard.svg')
-        ->when($user->can('access.dashboard'))
+        ->includeWhen($user->can('access.dashboard'))
 ])
 
 // In a view
@@ -35,11 +35,6 @@ You can install the package via composer:
 ```bash
 composer require nedwors/navigator
 ```
-
-> [!CAUTION]
-> Navigator v1 only supports Laravel <=12.9.2 as 12.10.0 introduced a breaking change.
->
-> `Conditionable` was added to `Fluent` which conflicted with the existing `when` and `unless` methods of `Item`
 
 ## Usage
 
@@ -127,18 +122,21 @@ $item->heroicon
 ```
 
 ##### Conditionals
-You can define conditionals to determine if the given `Item` should be displayed or not:
-```php
-Nav::item('Billing')->when(auth()->user()->is_subscribed)
+> [!NOTE]
+Version `1.0` and below of Navigator used the methods `when` and `unless`. Now that Laravel includes these methods using the `Conditionable` trait on `Fluent`, and to generally unify with Laravel conventions, these methods have been changed in Navigator `2.0` and above to `includeWhen` and `includeUnless`
 
-Nav::item('Registration')->unless(auth()->user()->is_subscribed)
+You can define conditionals to determine if the given `Item` should be included or not in the menu:
+```php
+Nav::item('Billing')->includeWhen(auth()->user()->is_subscribed)
+
+Nav::item('Registration')->includeUnless(auth()->user()->is_subscribed)
 ```
 They can also be composed:
 ```php
 Nav::item('Billing')
-    ->when($aCheck)
-    ->unless($someOtherCheck)
-    ->when($yetAnotherCheck)
+    ->includeWhen($aCheck)
+    ->includeUnless($someOtherCheck)
+    ->includeWhen($yetAnotherCheck)
 ```
 When your nav items are loaded, any falsey `Items` are filtered out by default.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,21 @@
 # Upgrade Guide
 
+## Unreleased
+
+### `when` and `unless` methods
+The `when` and `unless` methods have been renamed to `includeWhen` and `includeUnless` respectively.
+
+Update your application accordingly:
+```diff
+Nav::item('Home')
+-   ->when($someCondition)
++   ->includeWhen($someCondition)
+...
+Nav::item('Dashboard')
+-   ->unless($someCondition)
++   ->includeUnless($someCondition)
+```
+
 ## 1.0.0
 Navigator no longer supports the following:
 - Laravel 10 and below

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^11.0|>=12.0.0,<=12.9.2"
+        "illuminate/support": "^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.21",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c44623076a9f49fe5ad550dcd140b682",
+    "content-hash": "9231e8990a32df4cb20c667006fb13bd",
     "packages": [
         {
             "name": "brick/math",
@@ -1056,16 +1056,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.9.2",
+            "version": "v12.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "3db59aa0f382c349c78a92f3e5b5522e00e3301b"
+                "reference": "84b142958d1638a7e89de94ce75c2821c601d3d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/3db59aa0f382c349c78a92f3e5b5522e00e3301b",
-                "reference": "3db59aa0f382c349c78a92f3e5b5522e00e3301b",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/84b142958d1638a7e89de94ce75c2821c601d3d7",
+                "reference": "84b142958d1638a7e89de94ce75c2821c601d3d7",
                 "shasum": ""
             },
             "require": {
@@ -1086,7 +1086,7 @@
                 "guzzlehttp/uri-template": "^1.0",
                 "laravel/prompts": "^0.3.0",
                 "laravel/serializable-closure": "^1.3|^2.0",
-                "league/commonmark": "^2.6",
+                "league/commonmark": "^2.7",
                 "league/flysystem": "^3.25.1",
                 "league/flysystem-local": "^3.25.1",
                 "league/uri": "^7.5.1",
@@ -1178,7 +1178,7 @@
                 "php-http/discovery": "^1.15",
                 "phpstan/phpstan": "^2.0",
                 "phpunit/phpunit": "^10.5.35|^11.5.3|^12.0.1",
-                "predis/predis": "^2.3",
+                "predis/predis": "^2.3|^3.0",
                 "resend/resend-php": "^0.10.0",
                 "symfony/cache": "^7.2.0",
                 "symfony/http-client": "^7.2.0",
@@ -1210,7 +1210,7 @@
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (^5.0).",
                 "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
                 "phpunit/phpunit": "Required to use assertions and run tests (^10.5.35|^11.5.3|^12.0.1).",
-                "predis/predis": "Required to use the predis connector (^2.3).",
+                "predis/predis": "Required to use the predis connector (^2.3|^3.0).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
                 "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0|^7.0).",
                 "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0).",
@@ -1267,7 +1267,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-04-16T15:44:19+00:00"
+            "time": "2025-05-13T17:50:51+00:00"
         },
         {
             "name": "laravel/prompts",

--- a/src/Item.php
+++ b/src/Item.php
@@ -75,16 +75,16 @@ class Item extends Fluent
         return $this;
     }
 
-    public function when(?bool $condition): self
+    public function includeWhen(?bool $condition): self
     {
         $this->conditions[] = (bool) $condition;
 
         return $this;
     }
 
-    public function unless(?bool $condition): self
+    public function includeUnless(?bool $condition): self
     {
-        return $this->when(! (bool) $condition);
+        return $this->includeWhen(! (bool) $condition);
     }
 
     /** @param Closure(self): bool $activeCheck */

--- a/tests/Unit/Item/ItemTest.php
+++ b/tests/Unit/Item/ItemTest.php
@@ -82,16 +82,16 @@ if (version_compare(version(), '2') > -1) {
     it('has composable methods for availability', function (Item $item, bool $available) {
         expect($item->available)->toBe($available);
     })->with([
-        fn () => [(new Item)->when(true), true],
-        fn () => [(new Item)->when(false), false],
-        fn () => [(new Item)->when(true)->when(true), true],
-        fn () => [(new Item)->when(false)->when(true), false],
-        fn () => [(new Item)->unless(false), true],
-        fn () => [(new Item)->unless(true), false],
-        fn () => [(new Item)->unless(false)->unless(false), true],
-        fn () => [(new Item)->unless(true)->unless(false), false],
-        fn () => [(new Item)->when(true)->unless(false), true],
-        fn () => [(new Item)->when(true)->unless(true), false],
-        fn () => [(new Item)->when(false)->unless(false), false],
+        fn () => [(new Item)->includeWhen(true), true],
+        fn () => [(new Item)->includeWhen(false), false],
+        fn () => [(new Item)->includeWhen(true)->includeWhen(true), true],
+        fn () => [(new Item)->includeWhen(false)->includeWhen(true), false],
+        fn () => [(new Item)->includeUnless(false), true],
+        fn () => [(new Item)->includeUnless(true), false],
+        fn () => [(new Item)->includeUnless(false)->includeUnless(false), true],
+        fn () => [(new Item)->includeUnless(true)->includeUnless(false), false],
+        fn () => [(new Item)->includeWhen(true)->includeUnless(false), true],
+        fn () => [(new Item)->includeWhen(true)->includeUnless(true), false],
+        fn () => [(new Item)->includeWhen(false)->includeUnless(false), false],
     ]);
 }

--- a/tests/Unit/Nav/FilterTest.php
+++ b/tests/Unit/Nav/FilterTest.php
@@ -5,10 +5,10 @@ use Nedwors\Navigator\Item;
 
 it('filters out unavailable items by default', function () {
     Nav::define(fn () => [
-        Nav::item('Dashboard')->when(true),
-        Nav::item('Contact Us')->when(false),
-        Nav::item('Home')->unless(false),
-        Nav::item('Settings')->unless(true),
+        Nav::item('Dashboard')->includeWhen(true),
+        Nav::item('Contact Us')->includeWhen(false),
+        Nav::item('Home')->includeUnless(false),
+        Nav::item('Settings')->includeUnless(true),
     ]);
 
     expect(Nav::items())
@@ -22,11 +22,11 @@ it('filters out unavailable items by default', function () {
 it('can filter sub navs', function () {
     Nav::define(fn () => [
         Nav::item('Foo')->subItems([
-            Nav::item('Foo Child')->when(false),
+            Nav::item('Foo Child')->includeWhen(false),
         ]),
         Nav::item('Bar')->subItems([
-            Nav::item('Bar Child')->when(false),
-            Nav::item('Bar Child 2')->when(true),
+            Nav::item('Bar Child')->includeWhen(false),
+            Nav::item('Bar Child 2')->includeWhen(true),
         ]),
     ]);
 
@@ -45,10 +45,10 @@ it('can filter sub navs', function () {
 
 it('can have its filter defined', function () {
     Nav::define(fn () => [
-        Nav::item('Dashboard')->when(true),
-        Nav::item('Contact Us')->when(false),
-        Nav::item('Home')->unless(false),
-        Nav::item('Settings')->unless(true),
+        Nav::item('Dashboard')->includeWhen(true),
+        Nav::item('Contact Us')->includeWhen(false),
+        Nav::item('Home')->includeUnless(false),
+        Nav::item('Settings')->includeUnless(true),
     ]);
 
     Nav::filter(fn (Item $item) => $item->name == 'Dashboard' || $item->name == 'Settings');


### PR DESCRIPTION
Laravel now includes the `when` and `unless` methods using the `Conditionable` trait on `Fluent`. To mitigate this break, and to generally unify with Laravel conventions, these methods in Navigator have been changed `includeWhen` and `includeUnless`.